### PR TITLE
Rebrand SportDogLog to HuntDogLog across all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>SportDogLog</title>
+  <title>HuntDogLog</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style>
     body {
@@ -54,15 +54,15 @@
   </style>
 </head>
 <body>
-  <img src="logo-sportdoglog.png" alt="SportDogLog logo">
+  <img src="logo-huntdoglog.png" alt="HuntDogLog logo">
   <h1>Track Your Hunt. Log Every Detail. Elevate Your Dog's Performance.</h1>
-  <p>SportDogLog is the ultimate hunting companion for bird dog enthusiasts. Whether you're upland hunting or training in the off-season, SportDogLog makes it easy to capture key moments and insights from your hunt from your iPhone or Apple Watch.</p>
+  <p>HuntDogLog is the ultimate hunting companion for bird dog enthusiasts. Whether you're upland hunting or training in the off-season, HuntDogLog makes it easy to capture key moments and insights from your hunt from your iPhone or Apple Watch.</p>
   <a href="https://apps.apple.com/us/app/sportdoglog/id6749470983?itscg=30200&itsct=apps_box_badge&mttnsubad=6749470983" style="display: inline-block;">
     <img src="https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/en-us?releaseDate=1757289600" alt="Download on the App Store" style="width: 246px; height: 82px; vertical-align: middle; object-fit: contain;" />
   </a>
   <section class="instagram-section">
     <h2>Follow Along on Instagram</h2>
-    <p class="ig-handle"><a href="https://www.instagram.com/sportdoglog/" target="_blank" rel="noopener">@sportdoglog</a></p>
+    <p class="ig-handle"><a href="https://www.instagram.com/huntdoglog/" target="_blank" rel="noopener">@huntdoglog</a></p>
     <behold-widget feed-id="dTUHst3PGnMY0SdWrzYB"></behold-widget>
     <script>
       (() => {

--- a/privacy.html
+++ b/privacy.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Privacy Policy - SportDogLog</title>
+  <title>Privacy Policy - HuntDogLog</title>
 </head>
 <body style="font-family: Arial, sans-serif; padding: 2em; max-width: 800px; margin: auto;">
   <h1>Privacy Policy</h1>
   <p><strong>Effective Date:</strong> August 22, 2025</p>
-  <p>Welcome to SportDogLog (“we,” “us,” “our”). This Privacy Policy explains how we collect, use, and protect information when you use the SportDogLog app or visit our website (<strong>SportDogLog.com</strong>) (collectively, “Services”).</p>
+  <p>Welcome to HuntDogLog (“we,” “us,” “our”). This Privacy Policy explains how we collect, use, and protect information when you use the HuntDogLog app or visit our website (<strong>HuntDogLog.com</strong>) (collectively, “Services”).</p>
 
   <h2>1. Information We Collect</h2>
   <ul>
@@ -46,14 +46,14 @@
   <ul>
     <li>Manage or delete your data anytime within the app.</li>
     <li>Only you (authenticated) can access your logs.</li>
-    <li>Questions or requests? Email <a href="mailto:support@sportdoglog.com">support@sportdoglog.com</a>.</li>
+    <li>Questions or requests? Email <a href="mailto:support@huntdoglog.com">support@huntdoglog.com</a>.</li>
   </ul>
 
   <h2>6. Policy Updates</h2>
   <p>We may update this policy over time. Continued use signifies acceptance of any changes.</p>
 
   <h2>7. Contact</h2>
-  <p>For privacy-related questions, email <a href="mailto:support@sportdoglog.com">support@sportdoglog.com</a>.</p>
+  <p>For privacy-related questions, email <a href="mailto:support@huntdoglog.com">support@huntdoglog.com</a>.</p>
 
   <p><a href="index.html">← Back to Home</a></p>
 </body>

--- a/terms.html
+++ b/terms.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Terms of Use - SportDogLog</title>
+  <title>Terms of Use - HuntDogLog</title>
 </head>
 <body style="font-family: Arial, sans-serif; padding: 2em; max-width: 800px; margin: auto;">
   <h1>Terms of Use</h1>
   <p><strong>Effective Date:</strong> August 22, 2025</p>
-  <p>By using the SportDogLog app (“App”), you agree to these Terms of Use:</p>
+  <p>By using the HuntDogLog app (“App”), you agree to these Terms of Use:</p>
   <h2>1. License & Usage</h2>
   <p>You are granted a personal, non-exclusive license to use the App for non-commercial purposes.</p>
   <h2>2. App Usage & Accuracy</h2>
@@ -28,11 +28,11 @@
   <h2>8. Minors</h2>
   <p>Use is limited to users 13+ with parental consent if under 18.</p>
   <h2>9. Intellectual Property</h2>
-  <p>All SportDogLog content and branding are owned by us and protected by applicable laws.</p>
+  <p>All HuntDogLog content and branding are owned by us and protected by applicable laws.</p>
   <h2>10. Arbitration & Class Action Waiver</h2>
   <p>All disputes must be resolved individually and not via class action.</p>
   <h2>Contact</h2>
-  <p>Email us at <a href="mailto:support@sportdoglog.com">support@sportdoglog.com</a></p>
+  <p>Email us at <a href="mailto:support@huntdoglog.com">support@huntdoglog.com</a></p>
   <p><a href="index.html">← Back to Home</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
This PR updates all branding references from "SportDogLog" to "HuntDogLog" across the website and documentation pages.

## Key Changes
- Updated page titles in `index.html`, `privacy.html`, and `terms.html`
- Changed logo filename from `logo-sportdoglog.png` to `logo-huntdoglog.png`
- Updated all product name references in body text and descriptions
- Updated Instagram handle from `@sportdoglog` to `@huntdoglog`
- Updated support email addresses from `support@sportdoglog.com` to `support@huntdoglog.com`
- Updated website domain references from `SportDogLog.com` to `HuntDogLog.com`
- Updated copyright/IP statements to reference "HuntDogLog" instead of "SportDogLog"

## Files Modified
- `index.html` - Homepage branding and logo
- `privacy.html` - Privacy policy document
- `terms.html` - Terms of use document

All changes are consistent across all three pages to maintain unified branding throughout the site.

https://claude.ai/code/session_018WDHdPZhojN63WRBCkLFZy